### PR TITLE
Fix nix flake unwrapped lld and remove LD_LIBRARY_PATH workaround

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,14 +18,13 @@
           clang-yosys
           clang-tools_19
           clang_19
-          lld
+          llvmPackages.bintools
           llvm
           cmake
           gnumake
           ninja
         ];
         shellHook = ''
-          export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib:$LD_LIBRARY_PATH";
           export PATH=$PWD/circt/build/bin:$PATH;
         '';
       };


### PR DESCRIPTION
See [matklad's blog post](https://matklad.github.io/2022/03/14/rpath-or-why-lld-doesnt-work-on-nixos.html), particularly the last two paragraphs