### PR TITLE
Add subdirectories to .clangd to fix rtlil-emit language server

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,21 @@
-CompileFlags:
-  CompilationDatabase: ./circt/build
-Diagnostics:
-  Suppress: 
-    - "misc-definitions-in-headers"
+If:
+  PathMatch: "rtlil-emit/*"
+  CompileFlags:
+    CompilationDatabase: "rtlil-emit/build"
+
+---
+
+If:
+  PathMatch: "circt/*"
+  CompileFlags:
+    CompilationDatabase: "circt/build"
+  Diagnostics:
+    Suppress:
+      - "misc-definitions-in-headers"
+
+---
+
+If:
+  PathMatch: "circt/llvm/*"
+  CompileFlags:
+    CompilationDatabase: "circt/llvm/build"


### PR DESCRIPTION
This way the compile_commands.json for all three builds are found and applied to the right files